### PR TITLE
Fix curly braces is deprecated

### DIFF
--- a/lib/Horde/Compress/Tnef/Rtf.php
+++ b/lib/Horde/Compress/Tnef/Rtf.php
@@ -130,20 +130,20 @@ class Horde_Compress_Tnef_Rtf extends Horde_Compress_Tnef_Object
         $length_preload = strlen($preload);
 
         for ($cnt = 0; $cnt < $length_preload; $cnt++) {
-            $uncomp .= $preload{$cnt};
+            $uncomp .= $preload[$cnt];
             ++$out;
         }
 
         while ($out < ($this->_size + $length_preload)) {
             if (($flag_count++ % 8) == 0) {
-                $flags = ord($this->_data{$in++});
+                $flags = ord($this->_data[$in++]);
             } else {
                 $flags = $flags >> 1;
             }
 
             if (($flags & 1) != 0) {
-                $offset = ord($this->_data{$in++});
-                $length = ord($this->_data{$in++});
+                $offset = ord($this->_data[$in++]);
+                $length = ord($this->_data[$in++]);
                 $offset = ($offset << 4) | ($length >> 4);
                 $length = ($length & 0xF) + 2;
                 $offset = ((int)($out / 4096)) * 4096 + $offset;
@@ -156,7 +156,7 @@ class Horde_Compress_Tnef_Rtf extends Horde_Compress_Tnef_Object
                     ++$out;
                 }
             } else {
-                $uncomp .= $this->_data{$in++};
+                $uncomp .= $this->_data[$in++];
                 ++$out;
             }
         }


### PR DESCRIPTION
With PHP 7.4.0RC3

```
$ phpunit
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

......E...........                                                18 / 18 (100%)

Time: 61 ms, Memory: 14,55MB

There was 1 error:

1) Horde_Compress_TnefTest::testItipReply
Array and string offset access syntax with curly braces is deprecated

/work/GIT/horde/Compress/lib/Horde/Compress/Tnef/Rtf.php:139
/usr/share/pear/Horde/Test/Autoload.php:51
/usr/share/pear/Horde/Test/Autoload.php:51
/work/GIT/horde/Compress/lib/Horde/Compress/Tnef.php:514
/work/GIT/horde/Compress/lib/Horde/Compress/Tnef.php:654
/work/GIT/horde/Compress/lib/Horde/Compress/Tnef.php:295
/work/GIT/horde/Compress/test/Horde/Compress/TnefTest.php:45

ERRORS!
Tests: 18, Assertions: 63, Errors: 1.

```