### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Compress/Tnef/VTodo.php
+++ b/lib/Horde/Compress/Tnef/VTodo.php
@@ -20,6 +20,7 @@
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   Compress
  */
+#[\AllowDynamicProperties]
 class Horde_Compress_Tnef_VTodo extends Horde_Compress_Tnef_Object
 {
     const MAPI_TASK_STATUS          = 0x8101;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Compress/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Compress/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Compress Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Compress/RarTest.php
+++ b/test/Horde/Compress/RarTest.php
@@ -24,21 +24,22 @@
  */
 class Horde_Compress_RarTest extends Horde_Test_Case
 {
-    public function testInvalidRarData()
+    public function testInvalidRarData1()
     {
         $compress = Horde_Compress::factory('Rar');
 
-        try {
-            $compress->decompress('1234');
-            $this->fail('Expected exception.');
-        } catch (Horde_Compress_Exception $e) {}
+	$this->expectException('Horde_Compress_Exception');
+        $compress->decompress('1234');
+    }
 
-        try {
-            $compress->decompress(Horde_Compress_Rar::BLOCK_START . '1234');
-            $this->fail('Expected exception.');
-        } catch (Horde_Compress_Exception $e) {}
+    public function testInvalidRarData2()
+    {
+        $compress = Horde_Compress::factory('Rar');
 
-        $compress->decompress(Horde_Compress_Rar::BLOCK_START . '1234567');
+	$this->expectException('Horde_Compress_Exception');
+        $compress->decompress(Horde_Compress_Rar::BLOCK_START . '1234');
+        // this is a left-over line from refractored tests.
+        //$compress->decompress(Horde_Compress_Rar::BLOCK_START . '1234567');
     }
 
 }

--- a/test/Horde/Compress/TarTest.php
+++ b/test/Horde/Compress/TarTest.php
@@ -26,7 +26,7 @@ class Horde_Compress_TarTest extends Horde_Test_Case
 {
     protected $testdata;
 
-    public function setup()
+    protected function setup(): void
     {
         $this->testdata = str_repeat("0123456789ABCDE", 1000);
     }
@@ -70,7 +70,7 @@ class Horde_Compress_TarTest extends Horde_Test_Case
         ));
 
         $this->assertNotEmpty($tar_data);
-        $this->assertInternalType('resource', $tar_data);
+        $this->assertIsResource($tar_data);
 
         return stream_get_contents($tar_data);
     }

--- a/test/Horde/Compress/TnefTest.php
+++ b/test/Horde/Compress/TnefTest.php
@@ -26,7 +26,7 @@ class Horde_Compress_TnefTest extends Horde_Test_Case
 {
     public $testdata;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!class_exists('Horde_Mapi')) {
             $this->markTestSkipped('Horde_Mapi is not available');

--- a/test/Horde/Compress/ZipTest.php
+++ b/test/Horde/Compress/ZipTest.php
@@ -26,7 +26,7 @@ class Horde_Compress_ZipTest extends Horde_Test_Case
 {
     protected $testdata;
 
-    public function setup()
+    protected function setup(): void
     {
         $this->testdata = str_repeat("0123456789ABCDE", 1000);
     }
@@ -70,7 +70,7 @@ class Horde_Compress_ZipTest extends Horde_Test_Case
         ));
 
         $this->assertNotEmpty($zip_data);
-        $this->assertInternalType('resource', $zip_data);
+        $this->assertIsResource($zip_data);
 
         return stream_get_contents($zip_data);
     }

--- a/test/Horde/Compress/phpunit.xml
+++ b/test/Horde/Compress/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-compress/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-compress/-/blob/debian-sid/debian/patches/1012_php8.2.patch
